### PR TITLE
[34기 전지현] Feature/card-component 컴포넌트 분리

### DIFF
--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import Slider from 'react-slick';
+import * as S from './Card.styles';
+
+const Card = ({ id, name, description, bedCount, price, rating, imgs }) => {
+  return (
+    <Link to={`details/${id}`}>
+      <S.StyledCard id={id}>
+        <Slider dots={true} infinite={false}>
+          {imgs.map((img, idx) => (
+            <S.CardImg key={idx} src={img} alt="domi7" className="cardImg" />
+          ))}
+        </Slider>
+
+        <S.CardTexts>
+          <S.CardText>
+            <S.TitleLi>{name}</S.TitleLi>
+            <S.GrayLi>
+              {description.length >= 19
+                ? `${description.slice(0, 20)}...`
+                : description}
+            </S.GrayLi>
+            <S.GrayLi>침대 {bedCount}개</S.GrayLi>
+            <S.CardPrice>
+              <span>
+                {Number(price).toLocaleString('ko-KR', {
+                  style: 'currency',
+                  currency: 'KRW',
+                })}
+              </span>
+              / 박
+            </S.CardPrice>
+          </S.CardText>
+
+          <S.CardTextRate>
+            {rating}
+            <i class="fas fa-star star" />
+          </S.CardTextRate>
+        </S.CardTexts>
+      </S.StyledCard>
+    </Link>
+  );
+};
+
+export default Card;

--- a/src/components/Card/Card.styles.js
+++ b/src/components/Card/Card.styles.js
@@ -1,0 +1,88 @@
+import styled from 'styled-components';
+
+export const StyledCard = styled.div`
+  width: 294px;
+  height: max-content;
+
+  .slick-prev {
+    left: 10px;
+    border-radius: 50%;
+    z-index: 1;
+  }
+
+  .slick-next {
+    right: 10px;
+    border-radius: 50%;
+    z-index: 1;
+  }
+
+  .slick-prev:before,
+  .slick-next:before {
+    color: white;
+    font-size: 24px;
+  }
+
+  .slick-dots {
+    bottom: 9px;
+  }
+
+  .slick-dots li {
+    margin: 0;
+    width: 14px;
+    color: white;
+  }
+
+  .slick-dots li button:before {
+    color: white;
+    opacity: 0.6;
+    font-size: 5px;
+  }
+
+  .slick-dots li.slick-active button:before {
+    opacity: 1;
+  }
+`;
+
+export const CardImg = styled.img`
+  width: 292px;
+  height: 277px;
+  border-radius: 10%;
+  border-radius: 10px;
+`;
+
+export const CardTexts = styled.div`
+  display: flex;
+  padding: 13px 0;
+  font-size: 15px;
+`;
+
+export const CardText = styled.ul`
+  width: 80%;
+`;
+
+export const TitleLi = styled.li`
+  padding: 2px 0;
+  font-weight: 500;
+`;
+
+export const GrayLi = styled.li`
+  margin-top: 5px;
+  padding: 2px 0;
+  color: gray;
+  font-size: 14px;
+`;
+
+export const CardPrice = styled.li`
+  margin-top: 10px;
+`;
+
+export const CardTextRate = styled.p`
+  width: 20%;
+  height: 20px;
+  line-height: 20px;
+
+  .star {
+    padding-left: 5px;
+    font-size: 12px;
+  }
+`;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [x] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [x] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
-  기본 Main폴더에 있던 card 컴포넌트를 components 폴더로 분리
<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1.  Card컴포넌트는 main 페이지와 maplist 페이지에서 공통으로 쓰임.
    때문에 components 폴더에 두아 두 페이지에서 재사용 하려함.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
-  여러 페이지에서 재사용되는 컴포넌트는 page 폴더가 아니라, components 폴더에 두어 어려 페이지에서 공유되어야 한다.

<br />

## :: 기타 질문 및 특이 사항
- 리뷰 반영하였습니다 (07.09)